### PR TITLE
tracker: change delegate method for tracking vc changes

### DIFF
--- a/NavigationFlowCoordinator/NavigationControllerCoordinatorsTracker.swift
+++ b/NavigationFlowCoordinator/NavigationControllerCoordinatorsTracker.swift
@@ -49,7 +49,7 @@ extension NavigationControllerCoordinatorsTracker: CoordinatorsTracker {
 }
 
 extension NavigationControllerCoordinatorsTracker: UINavigationControllerDelegate {
-    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         cleanUpChildCoordinators()
     }
 }


### PR DESCRIPTION
Current method causes coordinators cleanup before view controller disappears, which leads to orphaned view controller if user cancels interactive pop gesture. This commit fixes that behaviour.